### PR TITLE
qtdeclarative 6.7.3: x11_gui_rebuilds

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/mesalib-feedstock/pr1/e7fea05

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/fe77d94
-  - https://staging.continuum.io/prefect/fs/qtsvg-feedstock/pr3/35a96f7
-  - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/5989151
+  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/1550c51
+  - https://staging.continuum.io/prefect/fs/qtsvg-feedstock/pr3/db5fd53
+  - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/a67f387

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/01c13ff
-  - https://staging.continuum.io/prefect/fs/qtsvg-feedstock/pr3/ca0b71a
-  - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/88c9288

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/1550c51
+  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/01c13ff
   - https://staging.continuum.io/prefect/fs/qtsvg-feedstock/pr3/db5fd53
   - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/a67f387

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,4 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/mesalib-feedstock/pr1/e7fea05
+  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/b35796f
+  - https://staging.continuum.io/prefect/fs/qtsvg-feedstock/pr3/7a7c22b
+  - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/ad82664

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/b35796f
-  - https://staging.continuum.io/prefect/fs/qtsvg-feedstock/pr3/7a7c22b
-  - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/ad82664
+  - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/fe77d94
+  - https://staging.continuum.io/prefect/fs/qtsvg-feedstock/pr3/35a96f7
+  - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/5989151

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
 channels:
   - https://staging.continuum.io/prefect/fs/qtbase-feedstock/pr7/01c13ff
-  - https://staging.continuum.io/prefect/fs/qtsvg-feedstock/pr3/db5fd53
-  - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/a67f387
+  - https://staging.continuum.io/prefect/fs/qtsvg-feedstock/pr3/ca0b71a
+  - https://staging.continuum.io/prefect/fs/qtshadertools-feedstock/pr3/88c9288

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,7 @@ test:
     - {{ compiler('cxx') }}
     - cmake
     - ninja
+    - qtbase-devel
   files:
     - run_qt_test.sh    # [unix]
     - run_qt_test.bat   # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,11 +39,7 @@ requirements:
     - qtsvg {{ version }}
     - qtshadertools {{ version }}
     # X11 dependencies
-    - libgl  # [linux]
     - libgl-devel  # [linux]
-    - mesa-libgl-devel  # [linux]
-    - mesalib  # [linux]
-    - libegl  # [linux]
     - libegl-devel  # [linux]
   run_constrained:
     - qt-main >={{ version }},<7
@@ -55,11 +51,7 @@ test:
     - cmake
     - ninja
     # X11 dependencies
-    - libgl  # [linux]
     - libgl-devel  # [linux]
-    - mesa-libgl-devel  # [linux]
-    - mesalib  # [linux]
-    - libegl  # [linux]
     - libegl-devel  # [linux]
   files:
     - run_qt_test.sh    # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ test:
     - {{ compiler('cxx') }}
     - cmake
     - ninja
-    - qtbase
+    - qtbase-devel
   files:
     - run_qt_test.sh    # [unix]
     - run_qt_test.bat   # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ test:
     - {{ compiler('cxx') }}
     - cmake
     - ninja
-    - qtbase-devel
+    - qtbase
   files:
     - run_qt_test.sh    # [unix]
     - run_qt_test.bat   # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,12 +35,9 @@ requirements:
     - perl
 
   host:
-    - qtbase {{ version }}
+    - qtbase-devel {{ version }}
     - qtsvg {{ version }}
     - qtshadertools {{ version }}
-    # X11 dependencies
-    - libgl-devel  # [linux]
-    - libegl-devel  # [linux]
   run_constrained:
     - qt-main >={{ version }},<7
     - qt >={{ version }},<7
@@ -50,9 +47,6 @@ test:
     - {{ compiler('cxx') }}
     - cmake
     - ninja
-    # X11 dependencies
-    - libgl-devel  # [linux]
-    - libegl-devel  # [linux]
   files:
     - run_qt_test.sh    # [unix]
     - run_qt_test.bat   # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - pkg-config  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,28 +22,14 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - {{ cdt('libdrm-devel') }}               # [linux]
-    - {{ cdt('libglvnd-glx') }}               # [linux and not x86_64]
-    - {{ cdt('libglvnd-egl') }}               # [linux and not x86_64]
-    - {{ cdt('libice-devel') }}               # [linux]
-    - {{ cdt('libsm-devel') }}                # [linux]
-    - {{ cdt('libx11-devel') }}               # [linux]
-    - {{ cdt('libxau-devel') }}               # [linux]
-    - {{ cdt('mesa-libgl-devel') }}           # [linux]
-    - {{ cdt('mesa-libgbm') }}                # [linux]
-    - {{ cdt('mesa-libegl-devel') }}          # [linux]
-    - {{ cdt('mesa-dri-drivers') }}           # [linux]
-    - {{ cdt('xcb-util-devel') }}             # [linux]
-    - {{ cdt('xcb-util-image-devel') }}       # [linux]
-    - {{ cdt('xcb-util-keysyms-devel') }}     # [linux]
-    - {{ cdt('xcb-util-renderutil-devel') }}  # [linux]
-    - {{ cdt('xcb-util-wm-devel') }}          # [linux]
-    - {{ cdt('xorg-x11-proto-devel') }}       # [linux]
-    - {{ cdt('libselinux') }}                 # [linux]
-    - {{ cdt('libxext') }}                    # [linux]
-    - {{ cdt('libxdamage') }}                 # [linux]
-    - {{ cdt('libxfixes') }}                  # [linux]
-    - {{ cdt('libxxf86vm') }}                 # [linux]
+    # TODO: map CDT libdrm-devel to new X11 package
+    # - { cdt('libdrm-devel') }
+    # TODO: map CDT mesa-libgbm to new X11 package
+    # - { cdt('mesa-libgbm') }
+    # TODO: map CDT mesa-libegl-devel to new X11 package
+    # - { cdt('mesa-libegl-devel') }
+    # TODO: map CDT libselinux to new X11 package
+    # - { cdt('libselinux') }
     - pkg-config  # [unix]
     - bison       # [linux]
     - flex        # [linux]
@@ -61,6 +47,42 @@ requirements:
     - qtsvg {{ version }}
     - qtshadertools {{ version }}
 
+    - libglx
+    - libegl
+    - xorg-libice
+    - xorg-libsm
+    - xorg-libx11
+    - xorg-libxau
+    - libgl-devel
+    - mesa-dri-drivers
+    - xcb-util
+    - xcb-util-image
+    - xcb-util-keysyms
+    - xcb-util-renderutil
+    - xcb-util-wm
+    - xorg-xproto
+    - xorg-libxext
+    - xorg-libxdamage
+    - xorg-libxfixes
+    - xorg-libxxf86vm
+    - libglx
+    - libegl
+    - xorg-libice
+    - xorg-libsm
+    - xorg-libx11
+    - xorg-libxau
+    - libgl-devel
+    - mesa-dri-drivers
+    - xcb-util
+    - xcb-util-image
+    - xcb-util-keysyms
+    - xcb-util-renderutil
+    - xcb-util-wm
+    - xorg-xproto
+    - xorg-libxext
+    - xorg-libxdamage
+    - xorg-libxfixes
+    - xorg-libxxf86vm
   run_constrained:
     - qt-main >={{ version }},<7
     - qt >={{ version }},<7
@@ -70,28 +92,14 @@ test:
     - {{ compiler('cxx') }}
     - cmake
     - ninja
-    - {{ cdt('libdrm-devel') }}               # [linux]
-    - {{ cdt('libglvnd-glx') }}               # [linux and not x86_64]
-    - {{ cdt('libglvnd-egl') }}               # [linux and not x86_64]
-    - {{ cdt('libice-devel') }}               # [linux]
-    - {{ cdt('libsm-devel') }}                # [linux]
-    - {{ cdt('libx11-devel') }}               # [linux]
-    - {{ cdt('libxau-devel') }}               # [linux]
-    - {{ cdt('mesa-libgl-devel') }}           # [linux]
-    - {{ cdt('mesa-libgbm') }}                # [linux]
-    - {{ cdt('mesa-libegl-devel') }}          # [linux]
-    - {{ cdt('mesa-dri-drivers') }}           # [linux]
-    - {{ cdt('xcb-util-devel') }}             # [linux]
-    - {{ cdt('xcb-util-image-devel') }}       # [linux]
-    - {{ cdt('xcb-util-keysyms-devel') }}     # [linux]
-    - {{ cdt('xcb-util-renderutil-devel') }}  # [linux]
-    - {{ cdt('xcb-util-wm-devel') }}          # [linux]
-    - {{ cdt('xorg-x11-proto-devel') }}       # [linux]
-    - {{ cdt('libselinux') }}                 # [linux]
-    - {{ cdt('libxext') }}                    # [linux]
-    - {{ cdt('libxdamage') }}                 # [linux]
-    - {{ cdt('libxfixes') }}                  # [linux]
-    - {{ cdt('libxxf86vm') }}                 # [linux]
+    # TODO: map CDT libdrm-devel to new X11 package
+    # - { cdt('libdrm-devel') }
+    # TODO: map CDT mesa-libgbm to new X11 package
+    # - { cdt('mesa-libgbm') }
+    # TODO: map CDT mesa-libegl-devel to new X11 package
+    # - { cdt('mesa-libegl-devel') }
+    # TODO: map CDT libselinux to new X11 package
+    # - { cdt('libselinux') }
   files:
     - run_qt_test.sh    # [unix]
     - run_qt_test.bat   # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,13 +6,13 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
+  - url: https://download.qt.io/archive/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
     sha256: 937b70e441abf5bc4e50d44d26610e2714a28514acf3885cd36116cd610b9875
     folder: {{ name }}
 
 build:
-  number: 0
-  skip: True  # [s390x or (osx and x86_64)]
+  number: 1
+  skip: True  # [osx and x86_64]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
   ignore_run_exports:
@@ -22,14 +22,6 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    # TODO: map CDT libdrm-devel to new X11 package
-    # - { cdt('libdrm-devel') }
-    # TODO: map CDT mesa-libgbm to new X11 package
-    # - { cdt('mesa-libgbm') }
-    # TODO: map CDT mesa-libegl-devel to new X11 package
-    # - { cdt('mesa-libegl-devel') }
-    # TODO: map CDT libselinux to new X11 package
-    # - { cdt('libselinux') }
     - pkg-config  # [unix]
     - bison       # [linux]
     - flex        # [linux]
@@ -46,43 +38,13 @@ requirements:
     - qtbase {{ version }}
     - qtsvg {{ version }}
     - qtshadertools {{ version }}
-
-    - libglx
-    - libegl
-    - xorg-libice
-    - xorg-libsm
-    - xorg-libx11
-    - xorg-libxau
-    - libgl-devel
-    - mesa-dri-drivers
-    - xcb-util
-    - xcb-util-image
-    - xcb-util-keysyms
-    - xcb-util-renderutil
-    - xcb-util-wm
-    - xorg-xproto
-    - xorg-libxext
-    - xorg-libxdamage
-    - xorg-libxfixes
-    - xorg-libxxf86vm
-    - libglx
-    - libegl
-    - xorg-libice
-    - xorg-libsm
-    - xorg-libx11
-    - xorg-libxau
-    - libgl-devel
-    - mesa-dri-drivers
-    - xcb-util
-    - xcb-util-image
-    - xcb-util-keysyms
-    - xcb-util-renderutil
-    - xcb-util-wm
-    - xorg-xproto
-    - xorg-libxext
-    - xorg-libxdamage
-    - xorg-libxfixes
-    - xorg-libxxf86vm
+    # X11 dependencies
+    - libgl  # [linux]
+    - libgl-devel  # [linux]
+    - mesa-libgl-devel  # [linux]
+    - mesalib  # [linux]
+    - libegl  # [linux]
+    - libegl-devel  # [linux]
   run_constrained:
     - qt-main >={{ version }},<7
     - qt >={{ version }},<7
@@ -92,14 +54,13 @@ test:
     - {{ compiler('cxx') }}
     - cmake
     - ninja
-    # TODO: map CDT libdrm-devel to new X11 package
-    # - { cdt('libdrm-devel') }
-    # TODO: map CDT mesa-libgbm to new X11 package
-    # - { cdt('mesa-libgbm') }
-    # TODO: map CDT mesa-libegl-devel to new X11 package
-    # - { cdt('mesa-libegl-devel') }
-    # TODO: map CDT libselinux to new X11 package
-    # - { cdt('libselinux') }
+    # X11 dependencies
+    - libgl  # [linux]
+    - libgl-devel  # [linux]
+    - mesa-libgl-devel  # [linux]
+    - mesalib  # [linux]
+    - libegl  # [linux]
+    - libegl-devel  # [linux]
   files:
     - run_qt_test.sh    # [unix]
     - run_qt_test.bat   # [win]


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7780](https://anaconda.atlassian.net/browse/PKG-7780)
- [Upstream repository]()

### Explanation of changes:

-

### Notes:

- Automated migration/rebuild for group x11_gui_rebuilds.


[PKG-7780]: https://anaconda.atlassian.net/browse/PKG-7780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ