### PR TITLE
Update to v6.9.1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,7 @@
 @REM https://bugreports.qt.io/browse/QTBUG-107009
 set "PATH=%SRC_DIR%\build\lib\qt6\bin;%PATH%"
 
-cmake -S"%SRC_DIR%/%PKG_NAME%" -B"%SRC_DIR%\build" -GNinja ^
+cmake --log-level STATUS -S"%SRC_DIR%/%PKG_NAME%" -B"%SRC_DIR%\build" -GNinja ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
     -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,9 +2,16 @@
 
 set -ex
 
-export LD_LIBRARY_PATH="${BUILD_PREFIX}/${HOST}/sysroot/usr/lib64:${BUILD_PREFIX}/${HOST}/sysroot/usr/lib:${LD_LIBRARY_PATH}"
+if [[ "${target_platform}" == osx-* ]]; then
+  CMAKE_ARGS="
+    ${CMAKE_ARGS}
+    -DQT_FORCE_WARN_APPLE_SDK_AND_XCODE_CHECK=ON
+    -DQT_APPLE_SDK_PATH=${CONDA_BUILD_SYSROOT}
+    -DQT_MAC_SDK_VERSION=${OSX_SDK_VER}
+  "
+fi
 
-cmake -S"${SRC_DIR}/${PKG_NAME}" -Bbuild -GNinja ${CMAKE_ARGS} \
+cmake --log-level STATUS -S"${SRC_DIR}/${PKG_NAME}" -Bbuild -GNinja ${CMAKE_ARGS} \
   -DCMAKE_PREFIX_PATH=${PREFIX} \
   -DCMAKE_INSTALL_PREFIX=${PREFIX} \
   -DCMAKE_INSTALL_RPATH=${PREFIX}/lib \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,8 +1,28 @@
-MACOSX_SDK_VERSION:                                          # [osx]
-  - '11.3'                                                   # [osx]
-CONDA_BUILD_SYSROOT:                                         # [osx]
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk  # [osx]
+# https://doc.qt.io/qt-6/macos.html
+c_stdlib_version:  # [not linux]
+  - 12.0           # [osx]
+  - 2022.12        # [win]
+OSX_SDK_VER:
+  - 13.3
+
+# https://doc.qt.io/qt-6/windows.html
 c_compiler:    # [win]
-  - vs2019     # [win]
+  - vs2022     # [win]
 cxx_compiler:  # [win]
-  - vs2019     # [win]
+  - vs2022     # [win]
+
+# XCode 15.0 came with SDK 14.0 and clang 15
+# https://en.wikipedia.org/wiki/Xcode
+c_compiler_version:    # [osx]
+  - 17                 # [osx]
+cxx_compiler_version:  # [osx]
+  - 17                 # [osx]
+
+# Need at least a 12.0 host or else tests will fail.
+extra_labels_for_os:
+  osx-arm64: [ventura]
+
+# Have to leave this for now or else the overlinking checks fail when we revert back to the aggregate CBC and use the
+# 11.1 sysroot.
+CONDA_BUILD_SYSROOT:
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
 {% set name = "qtdeclarative" %}
-{% set version = "6.7.3" %}
+{% set version = "6.9.1" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  - url: https://download.qt.io/archive/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: 937b70e441abf5bc4e50d44d26610e2714a28514acf3885cd36116cd610b9875
+  - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
+    sha256: ccb94665df0199d7ee387b965b29677c8b89cfb1782bb6f01239b1d1524cec97
     folder: {{ name }}
 
 build:
-  number: 1
+  number: 0
   skip: True  # [osx and x86_64]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
@@ -23,22 +23,24 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - pkg-config  # [unix]
-    - bison       # [linux]
-    - flex        # [linux]
-    - gperf       # [linux]
-    - jom         # [win]
-    - m2-bison    # [win]
-    - m2-flex     # [win]
-    - m2-gperf    # [win]
+    - pkg-config     # [unix]
+    - bison          # [linux]
+    - flex           # [linux]
+    - gperf          # [linux]
+    - jom            # [win]
+    - msys2-bison    # [win]
+    - msys2-flex     # [win]
+    - msys2-gperf    # [win]
     - cmake
     - ninja
     - perl
-
   host:
     - qtbase-devel {{ version }}
     - qtsvg {{ version }}
     - qtshadertools {{ version }}
+    # Vulkan support
+    - libvulkan-headers {{ libvulkan }}  # [not osx]
+    - libvulkan-loader {{ libvulkan }}   # [not osx]
   run_constrained:
     - qt-main >={{ version }},<7
     - qt >={{ version }},<7


### PR DESCRIPTION
qtdeclarative v6.9.1

**Destination channel:** defaults

### Links

- [PKG-8687](https://anaconda.atlassian.net/browse/PKG-8687)
- [Upstream repository](https://github.com/qt/qtdeclarative/tree/v6.9.1)
- [Upstream changelog/diff](https://github.com/qt/qtdeclarative/compare/v6.7.3...v6.9.1)
- Relevant dependency PRs:
  - AnacondaRecipes/qtbase-feedstock#9
  - AnacondaRecipes/qtshadertools-feedstock#4
  - AnacondaRecipes/qtsvg-feedstock#4

### Explanation of changes:

- Bump version
- Set SDK version on OSX and ignore Qt CMake errors about it not being enough


[PKG-8687]: https://anaconda.atlassian.net/browse/PKG-8687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ