### PR TITLE
qtdeclarative 6.10.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr19/96255f9
+  - https://staging.continuum.io/pbp/fs/qtshadertools-feedstock/pr7/0d24cd8
+  - https://staging.continuum.io/pbp/fs/qtsvg-feedstock/pr7/bdf4bf1

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/qtbase-feedstock/pr19/96255f9
-  - https://staging.continuum.io/pbp/fs/qtshadertools-feedstock/pr7/0d24cd8
-  - https://staging.continuum.io/pbp/fs/qtsvg-feedstock/pr7/bdf4bf1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,19 +1,12 @@
 @REM https://bugreports.qt.io/browse/QTBUG-107009
 set "PATH=%SRC_DIR%\build\lib\qt6\bin;%PATH%"
-::subst Y: "%SRC_DIR%"
-set BUILD_DIR=%SystemDrive%\qtdecl_%PKG_VERSION%
-if exist "%BUILD_DIR%" (
-    cd /d "%SystemDrive%\"
-    rmdir /s /q "%BUILD_DIR%"
-)
-mkdir "%BUILD_DIR%"
-if errorlevel 1 exit 1
+subst Y: "%SRC_DIR%"
 
-::cmake --log-level STATUS -S"Y:\%PKG_NAME%" -B"Y:\build" -GNinja ^
-cmake --log-level STATUS -S"%SRC_DIR%\%PKG_NAME%" -B"%BUILD_DIR%" -GNinja ^
+cmake --log-level STATUS -S"Y:\%PKG_NAME%" -B"Y:\build" -GNinja ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
     -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+    -DCMAKE_OBJECT_PATH_MAX=200 ^
     -DINSTALL_BINDIR=lib/qt6/bin ^
     -DINSTALL_PUBLICBINDIR=bin ^
     -DINSTALL_LIBEXECDIR=lib/qt6 ^
@@ -26,7 +19,7 @@ cmake --log-level STATUS -S"%SRC_DIR%\%PKG_NAME%" -B"%BUILD_DIR%" -GNinja ^
     -DINSTALL_DATADIR=share/qt6
 if errorlevel 1 exit 1
 
-cmake --build "%BUILD_DIR%" --target install
+cmake --build build --target install
 if errorlevel 1 exit 1
 
 xcopy /y /s %LIBRARY_PREFIX%\lib\qt6\bin\*.dll %LIBRARY_PREFIX%\bin
@@ -41,9 +34,5 @@ if errorlevel 1 exit 1
 copy %LIBRARY_PREFIX%\lib\qt6\bin\qmleasing.exe %LIBRARY_PREFIX%\bin\qmleasing6.exe
 if errorlevel 1 exit 1
 
-::cd %SRC_DIR%
-::subst Y: /D
-if exist "%BUILD_DIR%" (
-    cd /d "%SystemDrive%\"
-    rmdir /s /q "%BUILD_DIR%"
-)
+cd %SRC_DIR%
+subst Y: /D

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,12 +1,12 @@
 @REM https://bugreports.qt.io/browse/QTBUG-107009
-set "PATH=%SRC_DIR%\build\lib\qt6\bin;%PATH%"
-subst Y: "%SRC_DIR%"
+@REM Short build path on C: to avoid Windows path length limits on CI
+set "BUILD_DIR=%SystemDrive%\qtdecl_%PKG_VERSION%"
+set "PATH=%BUILD_DIR%\lib\qt6\bin;%PATH%"
 
-cmake --log-level STATUS -S"Y:\%PKG_NAME%" -B"Y:\build" -GNinja ^
+cmake --log-level STATUS -S"%SRC_DIR%\%PKG_NAME%" -B"%BUILD_DIR%" -GNinja ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
     -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
-    -DCMAKE_OBJECT_PATH_MAX=200 ^
     -DINSTALL_BINDIR=lib/qt6/bin ^
     -DINSTALL_PUBLICBINDIR=bin ^
     -DINSTALL_LIBEXECDIR=lib/qt6 ^
@@ -19,7 +19,7 @@ cmake --log-level STATUS -S"Y:\%PKG_NAME%" -B"Y:\build" -GNinja ^
     -DINSTALL_DATADIR=share/qt6
 if errorlevel 1 exit 1
 
-cmake --build build --target install
+cmake --build "%BUILD_DIR%" --target install
 if errorlevel 1 exit 1
 
 xcopy /y /s %LIBRARY_PREFIX%\lib\qt6\bin\*.dll %LIBRARY_PREFIX%\bin
@@ -34,5 +34,4 @@ if errorlevel 1 exit 1
 copy %LIBRARY_PREFIX%\lib\qt6\bin\qmleasing.exe %LIBRARY_PREFIX%\bin\qmleasing6.exe
 if errorlevel 1 exit 1
 
-cd %SRC_DIR%
-subst Y: /D
+rd /s /q "%BUILD_DIR%" 2>nul

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,16 @@
 @REM https://bugreports.qt.io/browse/QTBUG-107009
 set "PATH=%SRC_DIR%\build\lib\qt6\bin;%PATH%"
+::subst Y: "%SRC_DIR%"
+set BUILD_DIR=%SystemDrive%\qtdecl_%PKG_VERSION%
+if exist "%BUILD_DIR%" (
+    cd /d "%SystemDrive%\"
+    rmdir /s /q "%BUILD_DIR%"
+)
+mkdir "%BUILD_DIR%"
+if errorlevel 1 exit 1
 
-cmake --log-level STATUS -S"%SRC_DIR%/%PKG_NAME%" -B"%SRC_DIR%\build" -GNinja ^
+::cmake --log-level STATUS -S"Y:\%PKG_NAME%" -B"Y:\build" -GNinja ^
+cmake --log-level STATUS -S"%SRC_DIR%\%PKG_NAME%" -B"%BUILD_DIR%" -GNinja ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
     -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
@@ -17,7 +26,7 @@ cmake --log-level STATUS -S"%SRC_DIR%/%PKG_NAME%" -B"%SRC_DIR%\build" -GNinja ^
     -DINSTALL_DATADIR=share/qt6
 if errorlevel 1 exit 1
 
-cmake --build build --target install
+cmake --build "%BUILD_DIR%" --target install
 if errorlevel 1 exit 1
 
 xcopy /y /s %LIBRARY_PREFIX%\lib\qt6\bin\*.dll %LIBRARY_PREFIX%\bin
@@ -31,3 +40,10 @@ copy %LIBRARY_PREFIX%\lib\qt6\bin\qmlscene.exe %LIBRARY_PREFIX%\bin\qmlscene6.ex
 if errorlevel 1 exit 1
 copy %LIBRARY_PREFIX%\lib\qt6\bin\qmleasing.exe %LIBRARY_PREFIX%\bin\qmleasing6.exe
 if errorlevel 1 exit 1
+
+::cd %SRC_DIR%
+::subst Y: /D
+if exist "%BUILD_DIR%" (
+    cd /d "%SystemDrive%\"
+    rmdir /s /q "%BUILD_DIR%"
+)

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,7 +3,7 @@ c_stdlib_version:  # [not linux]
   - 12.0           # [osx]
   - 2022.12        # [win]
 OSX_SDK_VER:       # [osx]
-  - 13.3           # [osx]
+  - 14.5           # [osx]
 
 # https://doc.qt.io/qt-6/windows.html
 c_compiler:    # [win]
@@ -11,14 +11,12 @@ c_compiler:    # [win]
 cxx_compiler:  # [win]
   - vs2022     # [win]
 
-# XCode 15.0 came with SDK 14.0 and clang 15
+# XCode 15.0 came with SDK 14.0
 # https://en.wikipedia.org/wiki/Xcode
 c_compiler_version:    # [osx]
-  - 17                 # [osx]
+  - 20                 # [osx]
 cxx_compiler_version:  # [osx]
-  - 17                 # [osx]
+  - 20                 # [osx]
 
-# Have to leave this for now or else the overlinking checks fail when we revert back to the aggregate CBC and use the
-# 12.1 sysroot.
 CONDA_BUILD_SYSROOT:
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX13.3.sdk  # [osx and arm64]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX14.5.sdk  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qtdeclarative" %}
-{% set version = "6.9.2" %}
+{% set version = "6.10.1" %}
 
 package:
   name: {{ name }}
@@ -7,11 +7,11 @@ package:
 
 source:
   - url: https://download.qt.io/official_releases/qt/{{ version.rpartition('.')[0] }}/{{ version }}/submodules/{{ name }}-everywhere-src-{{ version }}.tar.xz
-    sha256: 477f2d2c0bd98916107818725e6d498206e033dfb2859c52121e01a06ac42664
+    sha256: 4fb4efb894e0b96288543505d69794d684bcfbe4940ce181d3e6817bda54843e
     folder: {{ name }}
 
 build:
-  number: 1
+  number: 0
   # https://doc.qt.io/qt-6/qt-releases.html#binary-compatibility
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}
@@ -32,12 +32,12 @@ requirements:
     - msys2-flex     # [win]
     - msys2-gperf    # [win]
     - cmake
-    - ninja
+    - ninja-base
     - perl
   host:
     - qtbase-devel {{ version }}
     - qtsvg {{ version }}
-    # https://github.com/qt/qtdeclarative/blob/v6.9.2/CMakeLists.txt#L45
+    # https://github.com/qt/qtdeclarative/blob/v6.10.1/CMakeLists.txt#L50
     - qtshadertools {{ version }}
     # Vulkan support
     - libvulkan-headers {{ libvulkan }}  # [not osx]
@@ -48,8 +48,8 @@ test:
     - {{ stdlib('c') }}  # [linux]
     - {{ compiler('cxx') }}
     - cmake
-    - ninja
-    - qtbase-devel
+    - ninja-base 
+    - qtbase-devel {{ version }}
   files:
     - run_qt_test.sh    # [unix]
     - run_qt_test.bat   # [win]


### PR DESCRIPTION
qtdeclarative 6.10.1

**Destination channel:**  defaults

### Links

- [PKG-11802](https://anaconda.atlassian.net/browse/PKG-11802) 

### Explanation of changes:

- Version update
- Build on win from the root directory:
**C:/Users/task_176944095093778/croot/qtdeclarative_1769441891379/work/build/src/quickcontrols/fluentwinui3/impl/CMakeFiles/qtquickcontrols2fluentwinui3styleimplplugin.dir/./** -> The directory is not created because windows cmake directory path length restriction.

[PKG-11802]: https://anaconda.atlassian.net/browse/PKG-11802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ